### PR TITLE
Wrong name of config path for "Show Shortcut" option

### DIFF
--- a/etc/adminhtml/system/advanced.xml
+++ b/etc/adminhtml/system/advanced.xml
@@ -40,7 +40,7 @@
         <field id="dp_show_shortcut" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Show Dotpay shortcut</label>
             <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-            <config_path>payment/dotpay_main/instruction</config_path>
+            <config_path>payment/dotpay_main/show_shortcut</config_path>
             <comment><![CDATA[Dotpay shortcut can be displayed in cart preview]]></comment>
         </field>
     </group>


### PR DESCRIPTION
"Show Dotpay shortcut" uses same field reference as "Display complete payment instruction" which is wrong.